### PR TITLE
Fix for Suggested Tags Closing Model + Debounced Tag Selection Input. ISSUE: #1

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
         "react-router": "^7.7.0",
+        "react-uid": "^2.4.0",
         "tailwind-scrollbar": "^4.0.2"
       },
       "devDependencies": {
@@ -3976,6 +3977,27 @@
       },
       "peerDependenciesMeta": {
         "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-uid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.4.0.tgz",
+      "integrity": "sha512-+MVs/25NrcZuGrmlVRWPOSsbS8y72GJOBsR7d68j3/wqOrRBF52U29XAw4+XSelw0Vm6s5VmGH5mCbTCPGVCVg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-router": "^7.7.0",
+    "react-uid": "^2.4.0",
     "tailwind-scrollbar": "^4.0.2"
   },
   "devDependencies": {

--- a/client/src/components/autoComplete/SearchInput.tsx
+++ b/client/src/components/autoComplete/SearchInput.tsx
@@ -13,13 +13,13 @@ interface Tag {
 }
 
 
-export default function SearchInput({suggestions, handleAddTag, reference,handleKeyDown, placeholder, className, onChange}:{suggestions?: Tag[], reference?: React.Ref<HTMLInputElement>, placeholder?: string, className?: string, onChange?:(e: React.ChangeEvent<HTMLInputElement>) => void, handleKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void, handleAddTag?:(tag:ITag, setAlreadySelected:any)=>void}) {
+export default function SearchInput({suggestions, handleAddTag, reference,handleKeyDown, placeholder, className, onChange, alreadySelected}:{suggestions?: Tag[], reference?: React.Ref<HTMLInputElement>, placeholder?: string, className?: string, onChange?:(e: React.ChangeEvent<HTMLInputElement>) => void, handleKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void, handleAddTag?:(tag:ITag)=>void, alreadySelected?: ITag[]}) {
   console.log("Suggestions in SearchInput:", suggestions);
   return (
     <div className='flex flex-col gap-2'>
       <SimpleInput handleKeyDown={handleKeyDown} onChange={onChange} reference={reference} placeholder={placeholder} className={`w-full rounded-xl text-gray-600 font-medium text-sm ${className}`}/>
       {
-         suggestions && suggestions.length > 0 ? <Suggestions handleAddTag={handleAddTag} tagsSuggestions={suggestions}/> : null
+         suggestions && suggestions.length > 0 ? <Suggestions handleAddTag={handleAddTag} tagsSuggestions={suggestions} alreadySelected={alreadySelected}/> : null
       }
     </div>
   )

--- a/client/src/components/autoComplete/SearchInput.tsx
+++ b/client/src/components/autoComplete/SearchInput.tsx
@@ -3,6 +3,7 @@ import { SimpleInput } from '../lib/Input'
 import Suggestions from './Suggestions';
 import debounce from 'lodash/debounce';
 import _ from 'lodash';
+import type { Tag as ITag } from "../createPost/AddPostModel"
 
 interface Tag {
   id: string;
@@ -12,12 +13,13 @@ interface Tag {
 }
 
 
-export default function SearchInput({suggestions, reference,handleKeyDown, placeholder, className, onChange}:{suggestions?: Tag[], reference?: React.Ref<HTMLInputElement>, placeholder?: string, className?: string, onChange?:(e: React.ChangeEvent<HTMLInputElement>) => void, handleKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void}) {
+export default function SearchInput({suggestions, handleAddTag, reference,handleKeyDown, placeholder, className, onChange}:{suggestions?: Tag[], reference?: React.Ref<HTMLInputElement>, placeholder?: string, className?: string, onChange?:(e: React.ChangeEvent<HTMLInputElement>) => void, handleKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void, handleAddTag?:(tag:ITag, setAlreadySelected:any)=>void}) {
+  console.log("Suggestions in SearchInput:", suggestions);
   return (
     <div className='flex flex-col gap-2'>
       <SimpleInput handleKeyDown={handleKeyDown} onChange={onChange} reference={reference} placeholder={placeholder} className={`w-full rounded-xl text-gray-600 font-medium text-sm ${className}`}/>
       {
-         suggestions && suggestions.length > 0 ? <Suggestions tagsSuggestions={suggestions}/> : null
+         suggestions && suggestions.length > 0 ? <Suggestions handleAddTag={handleAddTag} tagsSuggestions={suggestions}/> : null
       }
     </div>
   )

--- a/client/src/components/autoComplete/Suggestions.tsx
+++ b/client/src/components/autoComplete/Suggestions.tsx
@@ -1,3 +1,6 @@
+import { useCallback, useEffect, useState } from "react";
+import type { Tag as ITag } from "../createPost/AddPostModel";
+
 interface Tag{
   id:string,
   name:string,
@@ -5,13 +8,25 @@ interface Tag{
   updated_at:string
 }
 
-export default function Suggestions(props:{ tagsSuggestions: Tag[] }) {
+export default function Suggestions({tagsSuggestions,handleAddTag}:{ tagsSuggestions: Tag[], handleAddTag?: (tag: ITag,setAlreadySelected:any) => void }) {
+  const [ alreadySelected, setAlreadySelected ] = useState<Tag[]>([]);
+  const selectSuggestion = useCallback((tag:any) => {
+    console.log("tag : ",tag);
+    if(handleAddTag) {
+     handleAddTag(tag,setAlreadySelected);
+    }else{
+      console.warn("handleAddTag function is not provided.");
+    }
+    console.log("Selected tag:", tag);
+  }, [tagsSuggestions]);
+
+
   return (
-    <div className='w-full flex flex-col gap-1 max-h-[100px] overflow-y-scroll bg-gray-200 py-1 rounded-lg custom-scrollbar'>
+    <div onClick={(e) => e.stopPropagation()} className='w-full flex flex-col gap-1 max-h-[100px] overflow-y-scroll bg-gray-200 py-1 rounded-lg custom-scrollbar'>
       {
-        props.tagsSuggestions.map((tag) => (
-          <div key={tag.id} className='flex items-center justify-between px-3 py-2 rounded-lg hover:bg-gray-300 cursor-pointer transition-all duration-300'>
-            <span className='text-gray-700 hover:text-gray-600'>{tag.name}</span>
+        tagsSuggestions.map((tag) => (
+          <div key={tag.id} onClick={(e)=>{ e.stopPropagation(); selectSuggestion(tag)}} className='flex items-center justify-between px-3 py-2 rounded-lg hover:bg-gray-300 cursor-pointer transition-all duration-300'>
+            <span id="select" className={`${alreadySelected.map(ele=>ele.name).includes(tag.name) ? "text-primary-light" : "text-gray-700"} hover:text-gray-600`}>{tag.name}</span>
           </div>
         ))
       }

--- a/client/src/components/autoComplete/Suggestions.tsx
+++ b/client/src/components/autoComplete/Suggestions.tsx
@@ -8,12 +8,11 @@ interface Tag{
   updated_at:string
 }
 
-export default function Suggestions({tagsSuggestions,handleAddTag}:{ tagsSuggestions: Tag[], handleAddTag?: (tag: ITag,setAlreadySelected:any) => void }) {
-  const [ alreadySelected, setAlreadySelected ] = useState<Tag[]>([]);
+export default function Suggestions({tagsSuggestions,handleAddTag,alreadySelected}:{ tagsSuggestions: Tag[], handleAddTag?: (tag: ITag) => void, alreadySelected?: ITag[] }) {
   const selectSuggestion = useCallback((tag:any) => {
     console.log("tag : ",tag);
     if(handleAddTag) {
-     handleAddTag(tag,setAlreadySelected);
+     handleAddTag(tag);
     }else{
       console.warn("handleAddTag function is not provided.");
     }
@@ -26,7 +25,7 @@ export default function Suggestions({tagsSuggestions,handleAddTag}:{ tagsSuggest
       {
         tagsSuggestions.map((tag) => (
           <div key={tag.id} onClick={(e)=>{ e.stopPropagation(); selectSuggestion(tag)}} className='flex items-center justify-between px-3 py-2 rounded-lg hover:bg-gray-300 cursor-pointer transition-all duration-300'>
-            <span id="select" className={`${alreadySelected.map(ele=>ele.name).includes(tag.name) ? "text-primary-light" : "text-gray-700"} hover:text-gray-600`}>{tag.name}</span>
+            <span id="select" className={`${alreadySelected?.map(ele=>ele.name).includes(tag.name) ? "text-primary-light" : "text-gray-700"} hover:text-gray-600`}>{tag.name}</span>
           </div>
         ))
       }

--- a/client/src/components/createPost/AddPostModel.tsx
+++ b/client/src/components/createPost/AddPostModel.tsx
@@ -7,6 +7,7 @@ import { Dropdown } from "../lib/Input";
 import debounce from "lodash/debounce";
 import useToast from "../../hooks/useToast";
 import { Tags_URl } from "../../Endpoints";
+import { useUID } from 'react-uid';
 
 const categoryOptions = [
   { label: "Technology", value: "technology" },
@@ -30,6 +31,8 @@ export default function AddPostModel({className}: {className?: string}) {
   const [ query, setQuery ] = useState('');
   const [ category, setCategory ] = useState("");
   const [ tags, setTags ] = useState<Tag[]>([]);
+  const [ alreadySelected, setAlreadySelected ] = useState<Tag[]>([]);
+  const uid = useUID();
 
   const fetchTagSuggestions = async(query: string) => {
     if (!query.trim() || query.trim().length<2) return;
@@ -72,7 +75,7 @@ export default function AddPostModel({className}: {className?: string}) {
     setQuery(e.target.value);
   };
 
-  const handleAddTag = (tag: Tag, setAlreadySelected:any) => {
+  const handleAddTag = (tag: Tag) => {
     console.log('Adding tag:', tag);
     if (!tags.find((t) => t.name === tag.name)) {
       setTags((prev) => [...prev, tag]);
@@ -85,11 +88,9 @@ export default function AddPostModel({className}: {className?: string}) {
   };
 
   const handleAddNewTag = () => {
-    console.log('Adding new tag query:', query);
-    // if (query && !tags.find((t) => t.name === query)) {
-    //   const _id = Math.random().toString(36).substring(2, 15); 
-    //   handleAddTag({ name: query, _id:_id });
-    // }
+    if (query && !tags.find((t) => t.name === query)) {
+      handleAddTag({ name: query, _id:uid });
+    }
   };
 
   const handleRemoveTag = (name: string) => {
@@ -97,10 +98,11 @@ export default function AddPostModel({className}: {className?: string}) {
   };
 
   const keyEnterHandler=(e:any)=>{
-    // if (e.key === "Enter") {
-    //   e.preventDefault();
-    //   handleAddNewTag();
-    // }
+    console.log("Key pressed:", e.key);
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddNewTag();
+    }
   }
 
   const submitHandler = async (e: React.FormEvent) => {
@@ -122,14 +124,14 @@ export default function AddPostModel({className}: {className?: string}) {
           <CreateInput tagType="input" type="text" label="Title" required={true}/>
           <CreateInput tagType="textarea" type="textarea" label="Notes" required={false} placeholder="Add personal notes or key takeways.."/>
           <Dropdown placeholder="select a category" onSelect={(op)=>{setCategory(op.value)}} options={categoryOptions}/>
-          <CreateInput handleAddTag={handleAddTag} handleKeyDown={keyEnterHandler} onChange={handleInputChange} className="text-gray-500 text-[15px]" tagType="dropdown" label="Tags" required={true} reference={tagRef} suggestions={suggestions}/>
+          <CreateInput alreadySelected={alreadySelected} handleAddTag={handleAddTag} handleKeyDown={keyEnterHandler} onChange={handleInputChange} className="text-gray-500 text-[15px]" tagType="dropdown" label="Tags" required={true} reference={tagRef} suggestions={suggestions}/>
           {
             tags.length > 0 && (
               <div className="flex flex-wrap gap-2 mt-2">
                 {tags.map((tag) => (
                   <span key={tag._id} className="bg-gray-200 text-gray-700 px-3 py-1 rounded-full flex items-center gap-2">
                     {tag.name}
-                    <button type="button" onClick={() => handleRemoveTag(tag.name)} className="text-red-500 hover:text-red-700">&times;</button>
+                    <button type="button" onClick={() => handleRemoveTag(tag.name)} className="text-red-500 hover:text-red-700 cursor-pointer">&times;</button>
                   </span>
                 ))}
               </div>

--- a/client/src/components/createPost/AddPostModel.tsx
+++ b/client/src/components/createPost/AddPostModel.tsx
@@ -17,7 +17,7 @@ const categoryOptions = [
   { label: "Travel", value: "travel" }
 ]
 
-interface Tag{
+export interface Tag{
   _id: string;
   name: string;
 }
@@ -72,20 +72,24 @@ export default function AddPostModel({className}: {className?: string}) {
     setQuery(e.target.value);
   };
 
-  const handleAddTag = (tag: Tag) => {
+  const handleAddTag = (tag: Tag, setAlreadySelected:any) => {
+    console.log('Adding tag:', tag);
     if (!tags.find((t) => t.name === tag.name)) {
       setTags((prev) => [...prev, tag]);
+        setAlreadySelected((prev:any) => [...prev, tag]);
     }
     setQuery("");
     setSuggestions([]);
     if (tagRef.current) tagRef.current.value = "";
+    console.log(" tags object > ", tags);
   };
 
   const handleAddNewTag = () => {
-    if (query && !tags.find((t) => t.name === query)) {
-      const _id = Math.random().toString(36).substring(2, 15); 
-      handleAddTag({ name: query, _id:_id });
-    }
+    console.log('Adding new tag query:', query);
+    // if (query && !tags.find((t) => t.name === query)) {
+    //   const _id = Math.random().toString(36).substring(2, 15); 
+    //   handleAddTag({ name: query, _id:_id });
+    // }
   };
 
   const handleRemoveTag = (name: string) => {
@@ -93,10 +97,15 @@ export default function AddPostModel({className}: {className?: string}) {
   };
 
   const keyEnterHandler=(e:any)=>{
-    if (e.key === "Enter") {
-      e.preventDefault();
-      handleAddNewTag();
-    }
+    // if (e.key === "Enter") {
+    //   e.preventDefault();
+    //   handleAddNewTag();
+    // }
+  }
+
+  const submitHandler = async (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log('tags : ',tags);
   }
 
   return (
@@ -113,11 +122,23 @@ export default function AddPostModel({className}: {className?: string}) {
           <CreateInput tagType="input" type="text" label="Title" required={true}/>
           <CreateInput tagType="textarea" type="textarea" label="Notes" required={false} placeholder="Add personal notes or key takeways.."/>
           <Dropdown placeholder="select a category" onSelect={(op)=>{setCategory(op.value)}} options={categoryOptions}/>
-          <CreateInput handleKeyDown={keyEnterHandler} onChange={handleInputChange} className="text-gray-500 text-[15px]" tagType="dropdown" label="Tags" required={true} reference={tagRef} suggestions={suggestions}/>
+          <CreateInput handleAddTag={handleAddTag} handleKeyDown={keyEnterHandler} onChange={handleInputChange} className="text-gray-500 text-[15px]" tagType="dropdown" label="Tags" required={true} reference={tagRef} suggestions={suggestions}/>
+          {
+            tags.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-2">
+                {tags.map((tag) => (
+                  <span key={tag._id} className="bg-gray-200 text-gray-700 px-3 py-1 rounded-full flex items-center gap-2">
+                    {tag.name}
+                    <button type="button" onClick={() => handleRemoveTag(tag.name)} className="text-red-500 hover:text-red-700">&times;</button>
+                  </span>
+                ))}
+              </div>
+            )
+          }
       </form>
       <div className="flex gap-4 mt-4">
-        <CtaBtn label="Cancel" className="flex-1 flex justify-center items-center" variant="ghost" size="large" onClick={() => console.log("cancel")}/>
-        <CtaBtn label="Save Resource" className="flex-1 flex justify-center items-center" variant="primary" size="large" onClick={() => console.log("save")}/>
+        <CtaBtn label="Cancel" className="flex-1 flex justify-center items-center" variant="ghost" size="large"/>
+        <CtaBtn label="Save Resource" className="flex-1 flex justify-center items-center" variant="primary" size="large" onClick={submitHandler}/>
       </div>
     </div>
   )

--- a/client/src/components/createPost/createInput.tsx
+++ b/client/src/components/createPost/createInput.tsx
@@ -1,6 +1,7 @@
 import { AiInput, SimpleInput, TextArea } from "../lib/Input";
 import SearchInput from "../autoComplete/SearchInput";
 import Suggestions from "../autoComplete/Suggestions";
+import type { Tag } from "./AddPostModel";
 
 interface CreateInputProps {
   label?: string;
@@ -17,6 +18,7 @@ interface CreateInputProps {
   outerClass?: string;
   suggestions?: { id: string; name: string, created_at:string, updated_at:string }[]; 
   handleKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  handleAddTag?: (tag: Tag, setAlreadySelected:any) => void
 }
 
 export default function CreateInput(props:CreateInputProps) {
@@ -33,7 +35,7 @@ export default function CreateInput(props:CreateInputProps) {
         </span>
       </span>
       {
-        props.tagType === 'input' ?  <SimpleInput reference={props.reference} placeholder={props.placeholder} type={props.type} className={`w-full rounded-xl ${props.className}`}/> : props.tagType === 'textarea' ? <TextArea className="w-full rounded-xl" /> : props.tagType === "dropdown" ? <SearchInput handleKeyDown={props.handleKeyDown} onChange={props.onChange} reference={props.reference} placeholder={props.placeholder} className={props.className} suggestions={props.suggestions}/> : null
+        props.tagType === 'input' ?  <SimpleInput reference={props.reference} placeholder={props.placeholder} type={props.type} className={`w-full rounded-xl ${props.className}`}/> : props.tagType === 'textarea' ? <TextArea className="w-full rounded-xl" /> : props.tagType === "dropdown" ? <SearchInput handleAddTag={props.handleAddTag} handleKeyDown={props.handleKeyDown} onChange={props.onChange} reference={props.reference} placeholder={props.placeholder} className={props.className} suggestions={props.suggestions}/> : null
       }
     </div>
   )

--- a/client/src/components/createPost/createInput.tsx
+++ b/client/src/components/createPost/createInput.tsx
@@ -18,7 +18,8 @@ interface CreateInputProps {
   outerClass?: string;
   suggestions?: { id: string; name: string, created_at:string, updated_at:string }[]; 
   handleKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-  handleAddTag?: (tag: Tag, setAlreadySelected:any) => void
+  handleAddTag?: (tag: Tag) => void
+  alreadySelected?: Tag[];
 }
 
 export default function CreateInput(props:CreateInputProps) {
@@ -35,7 +36,7 @@ export default function CreateInput(props:CreateInputProps) {
         </span>
       </span>
       {
-        props.tagType === 'input' ?  <SimpleInput reference={props.reference} placeholder={props.placeholder} type={props.type} className={`w-full rounded-xl ${props.className}`}/> : props.tagType === 'textarea' ? <TextArea className="w-full rounded-xl" /> : props.tagType === "dropdown" ? <SearchInput handleAddTag={props.handleAddTag} handleKeyDown={props.handleKeyDown} onChange={props.onChange} reference={props.reference} placeholder={props.placeholder} className={props.className} suggestions={props.suggestions}/> : null
+        props.tagType === 'input' ?  <SimpleInput reference={props.reference} placeholder={props.placeholder} type={props.type} className={`w-full rounded-xl ${props.className}`}/> : props.tagType === 'textarea' ? <TextArea className="w-full rounded-xl" /> : props.tagType === "dropdown" ? <SearchInput alreadySelected={props.alreadySelected} handleAddTag={props.handleAddTag} handleKeyDown={props.handleKeyDown} onChange={props.onChange} reference={props.reference} placeholder={props.placeholder} className={props.className} suggestions={props.suggestions}/> : null
       }
     </div>
   )

--- a/client/src/components/lib/CtaBtn.tsx
+++ b/client/src/components/lib/CtaBtn.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 interface ButtonProps {
     label: string;
-    onClick: () => void;
+    onClick?: (e:React.FormEvent) => Promise<void>;
     disabled?: boolean;
     variant?: 'primary' | 'secondary' | 'ghost';
     size?: 'small' | 'medium' | 'large';


### PR DESCRIPTION
**Description**
This PR addresses and resolves the issue where clicking on any of the suggested tag items was causing both the dropdown and the create post model to close unexpectedly.

**Root Cause**
The root issue was due to event propagation — the click on the suggested tag option was bubbling up and triggering unintended parent handlers (like modal close).

**Fixes & Enhancements**
1. Fixed event propagation in tag suggestion items using e.stopPropagation() to prevent modal from closing.
2. Implemented debounced tag search input using lodash.debounce for efficient querying.
3. Properly managed tag selection using ref, avoiding unnecessary state.
4. Enhanced UX by displaying suggestions based on search query with improved keyboard handling (Enter key).

**ISSUE: #1**